### PR TITLE
Issue on Input Validators Assignment resolved

### DIFF
--- a/Form/FormFactory.php
+++ b/Form/FormFactory.php
@@ -35,12 +35,12 @@ class FormFactory
         $this->configuration = $configuration;
     }
 
-
     /**
      * This method genetates a form based on the configuration file.
      * @param string $name The name of the Form
      * @param array $data
      * @param array $options
+     *
      * @return \Symfony\Component\Form\Form
      * @throws InexistentFormException
      */
@@ -50,7 +50,7 @@ class FormFactory
             throw new InexistentFormException();
         }
 
-        $formBuilder = $this->formFactory->createBuilder('form', $data, $options);
+        $formBuilder = $this->formFactory->createNamedBuilder($name, 'form', $data, $options);
 
 
         foreach ($this->configuration[$name] as $name => $fieldConfiguration) {
@@ -60,10 +60,10 @@ class FormFactory
 
             $fieldOptions = isset($fieldConfiguration['options']) ? $fieldConfiguration['options'] : [];
 
-            if (isset($fieldConfiguration['validators'])) {
+            if (isset($fieldConfiguration['validation'])) {
                 $constraints = [];
 
-                foreach ($fieldConfiguration['validators'] as $validatorName => $options) {
+                foreach ($fieldConfiguration['validation'] as $validatorName => $options) {
                     $constraints[] = new $validatorName($options);
                 }
 
@@ -71,7 +71,6 @@ class FormFactory
             }
 
             $field = $formBuilder->create($name, $fieldConfiguration['type'], $fieldOptions);
-
 
             if (isset($fieldConfiguration['transformer'])) {
                 $transformerConfiguration = $fieldConfiguration['transformer'];
@@ -91,7 +90,7 @@ class FormFactory
 
         return $formBuilder->getForm();
     }
-
+    
     /**
      * @return string
      * @throws InexistentFormException

--- a/Tests/Form/FormFactoryTest.php
+++ b/Tests/Form/FormFactoryTest.php
@@ -76,7 +76,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
                 'field1' => [
                     'enabled' => true,
                     'type' => 'field1_type',
-                    'validators' => [
+                    'validation' => [
                         'Symfony\Component\Validator\Constraints\IsTrue' => [
                             'message' => 'The token is invalid.',
                         ],

--- a/Tests/Form/FormFactoryTest.php
+++ b/Tests/Form/FormFactoryTest.php
@@ -56,7 +56,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
             ->willReturn('foo_form');
 
         $formFactoryMock = $this->prophesize('\Symfony\Component\Form\FormFactory');
-        $formFactoryMock->createBuilder('form', ['foo_form_data'], ['foo_form_options'])
+        $formFactoryMock->createNamedBuilder('foo', ['foo_form_data'], ['foo_form_options'])
             ->shouldBeCalled()
             ->willReturn($formBuilderMock->reveal());
 
@@ -103,7 +103,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
             ->willReturn('foo_form');
 
         $formFactoryMock = $this->prophesize('\Symfony\Component\Form\FormFactory');
-        $formFactoryMock->createBuilder('form', [], [])
+        $formFactoryMock->createNamedBuilder('foo', [], [])
             ->shouldBeCalled()
             ->willReturn($formBuilderMock->reveal());
 
@@ -146,7 +146,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         $formFactory->setFormFactory($formFactoryMock->reveal());
         $formFactory->setConfiguration($formConfiguration);
 
-        $formFactoryMock->createBuilder('form', [], [])
+        $formFactoryMock->createNamedBuilder('foo', [], [])
             ->shouldBeCalled()
             ->willReturn($formBuilderMock->reveal());
 

--- a/Tests/Form/FormFactoryTest.php
+++ b/Tests/Form/FormFactoryTest.php
@@ -56,7 +56,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
             ->willReturn('foo_form');
 
         $formFactoryMock = $this->prophesize('\Symfony\Component\Form\FormFactory');
-        $formFactoryMock->createNamedBuilder('foo', ['foo_form_data'], ['foo_form_options'])
+        $formFactoryMock->createNamedBuilder('foo', 'form', ['foo_form_data'], ['foo_form_options'])
             ->shouldBeCalled()
             ->willReturn($formBuilderMock->reveal());
 
@@ -103,7 +103,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
             ->willReturn('foo_form');
 
         $formFactoryMock = $this->prophesize('\Symfony\Component\Form\FormFactory');
-        $formFactoryMock->createNamedBuilder('foo', [], [])
+        $formFactoryMock->createNamedBuilder('foo', 'form', [], [])
             ->shouldBeCalled()
             ->willReturn($formBuilderMock->reveal());
 
@@ -146,7 +146,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         $formFactory->setFormFactory($formFactoryMock->reveal());
         $formFactory->setConfiguration($formConfiguration);
 
-        $formFactoryMock->createNamedBuilder('foo', [], [])
+        $formFactoryMock->createNamedBuilder('foo', 'form', [], [])
             ->shouldBeCalled()
             ->willReturn($formBuilderMock->reveal());
 


### PR DESCRIPTION
* Code Style Correction
* Call to the method Symfony\Component\Form\FormFactory#createNamedBuilder instead of Symfony\Component\Form\FormFactory#createBuilder inside the FormFactory#createForm method in order to associate the received name param value as the Form name.
* Change in the access for validators assignment for a field from $fieldConfiguration['validators'] to $fieldConfiguration['validation'] in order to make it compatible with the yml tree structure defined in the Linio\DynamicFormBundle\DependencyInjection\Configuration class and assign the validators properly.
* Changes on Unit Test to make them compatibles with the changes made on the previous point.