### PR TITLE
Hotfix/aditional formly fields

### DIFF
--- a/Form/FormFactory.php
+++ b/Form/FormFactory.php
@@ -109,21 +109,21 @@ class FormFactory
     /**
      * @param string $name
      *
-     * @return string
+     * @return array
      *
      * @throws NonExistentFormException
      */
-    public function getJsonConfiguration($name = null)
+    public function getConfiguration($name = null)
     {
         if ($name === null) {
-            return json_encode($this->configuration);
+            return $this->configuration;
         }
 
         if (!$this->has($name)) {
             throw new NonExistentFormException();
         }
 
-        return json_encode($this->configuration[$name]);
+        return $this->configuration[$name];
     }
 
     /**

--- a/FormlyMapper/FormlyField.php
+++ b/FormlyMapper/FormlyField.php
@@ -57,7 +57,7 @@ abstract class FormlyField implements FormlyFieldInterface
                 $constraint = $validation[$notBlankConstraintClass];
 
                 if (isset($constraint['message'])) {
-                    $this->formlyFieldConfiguration['validation']['messages'] = $constraint['message'];
+                    $this->formlyFieldConfiguration['validation']['messages']['blank'] = $constraint['message'];
                 }
             }
 
@@ -68,7 +68,7 @@ abstract class FormlyField implements FormlyFieldInterface
                 $this->formlyFieldConfiguration['templateOptions']['pattern'] = $constraint['pattern'];
 
                 if (isset($constraint['message'])) {
-                    $this->formlyFieldConfiguration['validation']['messages'] = $constraint['message'];
+                    $this->formlyFieldConfiguration['validation']['messages']['regex'] = $constraint['message'];
                 }
             }
         }

--- a/FormlyMapper/FormlyField/DefaultField.php
+++ b/FormlyMapper/FormlyField/DefaultField.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Linio\DynamicFormBundle\FormlyMapper\FormlyField;
+
+/**
+ * @codeCoverageIgnore
+ */
+class DefaultField extends TextField
+{
+}

--- a/FormlyMapper/FormlyField/FormlyFieldFactory.php
+++ b/FormlyMapper/FormlyField/FormlyFieldFactory.php
@@ -48,6 +48,10 @@ class FormlyFieldFactory
      */
     public function getFormlyField($alias)
     {
-        return $this->formlyFields[$alias];
+        if ($this->has($alias)) {
+            return $this->formlyFields[$alias];
+        }
+
+        return $this->formlyFields['default'];
     }
 }

--- a/FormlyMapper/FormlyField/IntegerField.php
+++ b/FormlyMapper/FormlyField/IntegerField.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Linio\DynamicFormBundle\FormlyMapper\FormlyField;
+
+/**
+ * @codeCoverageIgnore
+ */
+class IntegerField extends NumberField
+{
+}

--- a/FormlyMapper/FormlyField/NumberField.php
+++ b/FormlyMapper/FormlyField/NumberField.php
@@ -24,13 +24,13 @@ class NumberField extends FormlyField
 
             if (isset($validation['Symfony\Component\Validator\Constraints\Range'])) {
                 $constraint = $validation['Symfony\Component\Validator\Constraints\Range'];
-                $this->formlyFieldConfiguration['templateOptions']['min'] = $constraint['min'];
+                $this->formlyFieldConfiguration['templateOptions']['min'] = isset($constraint['min']) ? $constraint['min'] : '';
 
                 if (isset($constraint['minMessage'])) {
                     $this->formlyFieldConfiguration['validation']['messages']['min'] = $constraint['minMessage'];
                 }
 
-                $this->formlyFieldConfiguration['templateOptions']['max'] = $constraint['max'];
+                $this->formlyFieldConfiguration['templateOptions']['max'] = isset($constraint['max']) ? $constraint['max'] : '';
 
                 if (isset($constraint['maxMessage'])) {
                     $this->formlyFieldConfiguration['validation']['messages']['max'] =  $constraint['maxMessage'];

--- a/FormlyMapper/FormlyField/UrlField.php
+++ b/FormlyMapper/FormlyField/UrlField.php
@@ -13,4 +13,19 @@ class UrlField extends FormlyField
     {
         return 'url';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function buildFieldTypeConfiguration()
+    {
+        if (isset($this->fieldConfiguration['validation'])) {
+            $validation = $this->fieldConfiguration['validation'];
+
+            if (isset($validation['Symfony\Component\Validator\Constraints\Url'])) {
+                $constraint = $validation['Symfony\Component\Validator\Constraints\Url'];
+                $this->formlyFieldConfiguration['validation']['messages']['url'] =  isset($constraint['message']) ? $constraint['message'] : '';
+            }
+        }
+    }
 }

--- a/FormlyMapper/FormlyMapper.php
+++ b/FormlyMapper/FormlyMapper.php
@@ -60,7 +60,7 @@ class FormlyMapper
         $formlyConfiguration = [];
 
         try {
-            $configuration = (array) $this->formFactory->getJsonConfiguration($formName);
+            $configuration = (array) $this->formFactory->getConfiguration($formName);
         } catch(NonExistentFormException $e) {
             throw new FormlyMapperException($e->getMessage());
         }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -27,6 +27,12 @@ services:
         tags:
             - {name: formly_field, alias: date}
 
+    formly_field.default:
+        class: Linio\DynamicFormBundle\FormlyMapper\FormlyField\DefaultField
+        lazy: true
+        tags:
+            - {name: formly_field, alias: default}
+
     formly_field.email:
         class: Linio\DynamicFormBundle\FormlyMapper\FormlyField\EmailField
         lazy: true
@@ -50,6 +56,12 @@ services:
         lazy: true
         tags:
             - {name: formly_field, alias: hidden}
+
+    formly_field.integer:
+        class: Linio\DynamicFormBundle\FormlyMapper\FormlyField\IntegerField
+        lazy: true
+        tags:
+            - {name: formly_field, alias: integer}
 
     formly_field.number:
         class: Linio\DynamicFormBundle\FormlyMapper\FormlyField\NumberField
@@ -86,3 +98,9 @@ services:
         lazy: true
         tags:
             - {name: formly_field, alias: time}
+
+    formly_field.url:
+        class: Linio\DynamicFormBundle\FormlyMapper\FormlyField\UrlField
+        lazy: true
+        tags:
+            - {name: formly_field, alias: url}

--- a/Tests/Form/FormFactoryTest.php
+++ b/Tests/Form/FormFactoryTest.php
@@ -159,9 +159,9 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo_form', $actual);
     }
 
-    public function testIsGettingJsonConfiguration()
+    public function testIsGettingConfiguration()
     {
-        $this->formFactory->setConfiguration([
+        $configuration = [
             'foo' => [
                 'email' => [
                     'enabled' => true,
@@ -172,16 +172,20 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
                     'type' => 'password',
                 ],
             ],
-        ]);
+        ];
 
-        $actual = $this->formFactory->getJsonConfiguration('foo');
-        $expected = '{"email":{"enabled":true,"type":"email"},"password":{"enabled":false,"type":"password"}}';
+        $this->formFactory->setConfiguration($configuration);
+
+        $expected = $configuration['foo'];
+
+        $actual = $this->formFactory->getConfiguration('foo');
+
         $this->assertEquals($expected, $actual);
     }
 
     public function testIsHandlingNullName()
     {
-        $this->formFactory->setConfiguration([
+        $configuration = [
             'foo' => [
                 'email' => [
                     'enabled' => true,
@@ -192,11 +196,13 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
                     'type' => 'password',
                 ],
             ],
-        ]);
+        ];
 
-        $actual = $this->formFactory->getJsonConfiguration(null);
-        $expected = '{"foo":{"email":{"enabled":true,"type":"email"},"password":{"enabled":false,"type":"password"}}}';
-        $this->assertEquals($expected, $actual);
+        $this->formFactory->setConfiguration($configuration);
+
+        $actual = $this->formFactory->getConfiguration(null);
+
+        $this->assertEquals($configuration, $actual);
     }
 
     /**
@@ -204,7 +210,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testIsHandlingNotExistenFormException()
     {
-        $this->formFactory->setConfiguration([
+        $configuration = [
             'foo' => [
                 'email' => [
                     'enabled' => true,
@@ -215,9 +221,11 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
                     'type' => 'password',
                 ],
             ],
-        ]);
+        ];
 
-        $this->formFactory->getJsonConfiguration('bar');
+        $this->formFactory->setConfiguration($configuration);
+
+        $this->formFactory->getConfiguration('bar');
     }
 
     public function setup()

--- a/Tests/FormlyMapper/FormlyField/DateFieldTest.php
+++ b/Tests/FormlyMapper/FormlyField/DateFieldTest.php
@@ -38,7 +38,9 @@ class DateFieldTest extends \PHPUnit_Framework_TestCase
                 'pattern' => '^[0-9]{4}\-[0-9]{2}\-[0-9]{2}$',
             ],
             'validation' => [
-                'messages' => 'The birthday field must follow the pattern "yyyy-MM-dd"',
+                'messages' => [
+                    'regex' => 'The birthday field must follow the pattern "yyyy-MM-dd"',
+                ],
             ],
         ];
 

--- a/Tests/FormlyMapper/FormlyField/EmailFieldTest.php
+++ b/Tests/FormlyMapper/FormlyField/EmailFieldTest.php
@@ -38,7 +38,9 @@ class EmailFieldTest extends \PHPUnit_Framework_TestCase
                 'pattern' => '/^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,3})$/i',
             ],
             'validation' => [
-                'messages' => 'The email do not have the correct format',
+                'messages' => [
+                    'regex' => 'The email do not have the correct format',
+                ],
             ],
         ];
 

--- a/Tests/FormlyMapper/FormlyField/EntityFieldTest.php
+++ b/Tests/FormlyMapper/FormlyField/EntityFieldTest.php
@@ -43,7 +43,9 @@ class EntityFieldTest extends \PHPUnit_Framework_TestCase
                 'multiple' => false,
             ],
             'validation' => [
-                'messages' => 'Invalid entity Id',
+                'messages' => [
+                    'regex' => 'Invalid entity Id',
+                ],
             ],
         ];
 

--- a/Tests/FormlyMapper/FormlyField/FormlyFieldFactoryTest.php
+++ b/Tests/FormlyMapper/FormlyField/FormlyFieldFactoryTest.php
@@ -2,33 +2,50 @@
 
 namespace Linio\DynamicFormBundle\Tests\FormlyMapper\FormlyField;
 
+use Linio\DynamicFormBundle\FormlyMapper\FormlyField\DefaultField;
 use Linio\DynamicFormBundle\FormlyMapper\FormlyField\FormlyFieldFactory;
 use Linio\DynamicFormBundle\FormlyMapper\FormlyField\NumberField;
 
 class FormlyFieldFactoryTest extends \PHPUnit_Framework_TestCase
 {
-    public function testIsAddingOneFormlyField()
+    public function testIsHasTheFormlyField()
     {
         $alias = 'number';
         $formlyField = new NumberField();
 
         $formlyFieldFactory = new FormlyFieldFactory();
         $formlyFieldFactory->addFormlyField($alias, $formlyField);
+
+        $actual = $formlyFieldFactory->has($alias);
+
+        $this->assertTrue($actual);
     }
 
-    public function testIsHasTheFormlyField()
+    public function testIsGettingSpecificFormlyFieldInstance()
     {
         $alias = 'number';
+        $formlyField = new NumberField();
 
         $formlyFieldFactory = new FormlyFieldFactory();
-        $formlyFieldFactory->has($alias);
+        $formlyFieldFactory->addFormlyField($alias, $formlyField);
+
+        $actual = $formlyFieldFactory->getFormlyField($alias);
+
+        $this->assertInstanceOf('Linio\DynamicFormBundle\FormlyMapper\FormlyFieldInterface', $actual);
     }
 
-    public function testIsGettingTheFormlyFieldInstance()
+    public function testIsGettingDefaultFormlyFieldInstance()
     {
-        $alias = 'number';
-
         $formlyFieldFactory = new FormlyFieldFactory();
-        $formlyFieldFactory->getFormlyField($alias);
+
+        $numberField = new NumberField();
+        $formlyFieldFactory->addFormlyField('number', $numberField);
+
+        $dafaultField = new DefaultField();
+        $formlyFieldFactory->addFormlyField('default', $dafaultField);
+
+        $actual = $formlyFieldFactory->getFormlyField('file');
+
+        $this->assertInstanceOf('Linio\DynamicFormBundle\FormlyMapper\FormlyFieldInterface', $actual);
     }
 }

--- a/Tests/FormlyMapper/FormlyField/NumberFieldTest.php
+++ b/Tests/FormlyMapper/FormlyField/NumberFieldTest.php
@@ -108,7 +108,9 @@ class NumberFieldTest extends \PHPUnit_Framework_TestCase
                 'pattern' => '^[0-9]{2}$',
             ],
             'validation' => [
-                'messages' => 'Invalid allowed age',
+                'messages' => [
+                    'regex' => 'Invalid allowed age',
+                ],
             ],
         ];
 

--- a/Tests/FormlyMapper/FormlyField/PasswordFieldTest.php
+++ b/Tests/FormlyMapper/FormlyField/PasswordFieldTest.php
@@ -38,7 +38,9 @@ class PasswordFieldTest extends \PHPUnit_Framework_TestCase
                 'pattern' => '^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,3})$',
             ],
             'validation' => [
-                'messages' => 'Password must have 1 capital letter, 1 lower case letter, 1 digit or special character and must be longer than 8 characters',
+                'messages' => [
+                    'regex' => 'Password must have 1 capital letter, 1 lower case letter, 1 digit or special character and must be longer than 8 characters',
+                ],
             ],
         ];
 

--- a/Tests/FormlyMapper/FormlyField/SearchFieldTest.php
+++ b/Tests/FormlyMapper/FormlyField/SearchFieldTest.php
@@ -36,7 +36,9 @@ class SearchFieldTest extends \PHPUnit_Framework_TestCase
                 'required' => true,
             ],
             'validation' => [
-                'messages' => 'Search field is mandatory',
+                'messages' => [
+                    'blank' => 'Search field is mandatory',
+                ],
             ],
         ];
 

--- a/Tests/FormlyMapper/FormlyField/TextFieldTest.php
+++ b/Tests/FormlyMapper/FormlyField/TextFieldTest.php
@@ -63,7 +63,9 @@ class TextFieldTest extends \PHPUnit_Framework_TestCase
                 'required' => true,
             ],
             'validation' => [
-                'messages' => 'Name is mandatory',
+                'messages' => [
+                    'blank' => 'Name is mandatory',
+                ],
             ],
         ];
 

--- a/Tests/FormlyMapper/FormlyField/TextareaFieldTest.php
+++ b/Tests/FormlyMapper/FormlyField/TextareaFieldTest.php
@@ -36,7 +36,9 @@ class TextareaFieldTest extends \PHPUnit_Framework_TestCase
                 'required' => true,
             ],
             'validation' => [
-                'messages' => 'Comments field is mandatory',
+                'messages' => [
+                    'blank' => 'Comments field is mandatory',
+                ],
             ],
         ];
 

--- a/Tests/FormlyMapper/FormlyField/TimeFieldTest.php
+++ b/Tests/FormlyMapper/FormlyField/TimeFieldTest.php
@@ -38,7 +38,9 @@ class TimeFieldTest extends \PHPUnit_Framework_TestCase
                 'pattern' => '^[0-9]{2}\:[0-9]{2}\:[0-9]{2}$',
             ],
             'validation' => [
-                'messages' => 'The time must follow the pattern hh:mm:ss',
+                'messages' => [
+                    'regex' => 'The time must follow the pattern hh:mm:ss',
+                ],
             ],
         ];
 

--- a/Tests/FormlyMapper/FormlyField/UrlFieldTest.php
+++ b/Tests/FormlyMapper/FormlyField/UrlFieldTest.php
@@ -21,8 +21,7 @@ class UrlFieldTest extends \PHPUnit_Framework_TestCase
                 'label' => 'URL',
             ],
             'validation' => [
-                'Symfony\Component\Validator\Constraints\Regex' => [
-                    'pattern' => '^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \?=.-]*)*\/?$',
+                'Symfony\Component\Validator\Constraints\Url' => [
                     'message' => 'The url do not have the correct format',
                 ],
             ],
@@ -35,10 +34,11 @@ class UrlFieldTest extends \PHPUnit_Framework_TestCase
                 'type' => 'url',
                 'label' => 'URL',
                 'required' => true,
-                'pattern' => '^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \?=.-]*)*\/?$',
             ],
             'validation' => [
-                'messages' => 'The url do not have the correct format',
+                'messages' => [
+                    'url' => 'The url do not have the correct format',
+                ],
             ],
         ];
 

--- a/Tests/FormlyMapper/FormlyMapperTest.php
+++ b/Tests/FormlyMapper/FormlyMapperTest.php
@@ -53,6 +53,12 @@ class FormlyMapperTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
+        $this->formFactoryMock->getConfiguration($formName)
+            ->willReturn($configuration);
+
+        $this->formlyFieldFactoryMock->getFormlyField($formType)
+            ->willReturn($this->formlyFieldMock->reveal());
+
         $fieldConfiguration = [
             'name' => 'width',
             'type' => 'number',
@@ -61,6 +67,9 @@ class FormlyMapperTest extends \PHPUnit_Framework_TestCase
                 'label' => 'Width',
             ],
         ];
+
+        $this->formlyFieldMock->setFieldConfiguration($fieldConfiguration)
+            ->shouldBeCalled();
 
         $formlyConfiguration = [
             [
@@ -74,24 +83,6 @@ class FormlyMapperTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
-        $expected = [
-            $formlyConfiguration,
-            [
-                'key' => '_token',
-                'type' => 'hidden',
-                'defaultValue' => 'bar',
-            ],
-        ];
-
-        $this->formFactoryMock->getJsonConfiguration($formName)
-            ->willReturn($configuration);
-
-        $this->formlyFieldFactoryMock->getFormlyField($formType)
-            ->willReturn($this->formlyFieldMock->reveal());
-
-        $this->formlyFieldMock->setFieldConfiguration($fieldConfiguration)
-            ->shouldBeCalled();
-
         $this->formlyFieldMock->getFormlyFieldConfiguration()
             ->willReturn($formlyConfiguration);
 
@@ -101,6 +92,15 @@ class FormlyMapperTest extends \PHPUnit_Framework_TestCase
         $this->formlyMapper->setFormFactory($this->formFactoryMock->reveal());
         $this->formlyMapper->setFormlyFieldFactory($this->formlyFieldFactoryMock->reveal());
         $this->formlyMapper->setCsrfTokenManager($this->csrfTokenManagerMock->reveal());
+
+        $expected = [
+            $formlyConfiguration,
+            [
+                'key' => '_token',
+                'type' => 'hidden',
+                'defaultValue' => 'bar',
+            ],
+        ];
 
         $actual = $this->formlyMapper->map($formName);
 
@@ -114,7 +114,7 @@ class FormlyMapperTest extends \PHPUnit_Framework_TestCase
     {
         $formName = 'foo';
 
-        $this->formFactoryMock->getJsonConfiguration($formName)
+        $this->formFactoryMock->getConfiguration($formName)
             ->willThrow('Linio\DynamicFormBundle\Exception\NonExistentFormException');
 
         $this->formlyMapper->setFormFactory($this->formFactoryMock->reveal());


### PR DESCRIPTION
- Refactored `getJsonConfiguration` to return an `array`.
- Created additional formly fields.
- Added `has` validation to return an specific instance or return a default instance.
- Refactored validation messages as `array`.