### PR TITLE
docs: change type of data to mixed for Form Interface

### DIFF
--- a/src/Form/FormFactory.php
+++ b/src/Form/FormFactory.php
@@ -82,7 +82,7 @@ class FormFactory
 
     /**
      * @param string $key     The key of the Form in the form configuration
-     * @param array  $data
+     * @param mixed  $data
      * @param array  $options
      * @param string $name    An name for the form. If empty, the key will be used
      *


### PR DESCRIPTION
The method `createForm` can allow more types than array on the `data` params.

Also the returning value is of type `FormInterface` which on getData is a mixed type: https://github.com/symfony/form/blob/master/FormInterface.php#L121

**Why**
When upgrading versions of linting tools (phpstan), the method `createForm` is being used with objects as arguments on the `data` parameter which produce an error.